### PR TITLE
Fix the event error code in _getCurrencyHistoricData

### DIFF
--- a/cryptoprice-dash.html
+++ b/cryptoprice-dash.html
@@ -147,8 +147,8 @@
             }
 
             _getCurrencyHistoricData(currency) {
-                if (event !== undefined) {
-                    currency = event.target.dataset.item;
+                if (currency instanceof Event){
+                    currency=currency.target.dataset.item;
                 }
                 var ajax = this.$.coinbase;
                 ajax.url = 'https://api.coinbase.com/v2/prices/' + currency + '-USD/historic?period=week';


### PR DESCRIPTION
@dante, thanks for fix.
Solution: Add following lines at the beginning of the _getCurrencyHistoricData(currency) method:

if (currency instanceof Event){
    currency=currency.target.dataset.item;
}
It seems, for some reason, that the item attribute is not accesible in event.target.dataset.item nor event.model.item, both of them throw the same error. The code I added asks whether currency is an instance of Event, which means that _getCurrencyHistoricData was triggered by an event (in this case: on-click event), if this happens, we get the atrribute from the currency variable.